### PR TITLE
Change minimum required python from 3.7 to 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setuptools.setup(
         "roxar_api_utils.surfaces",
         "roxar_api_utils.wells",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
Roxar API utils as per today will work and RMS 12.0 and 11.*  (which uses Python 3.6)